### PR TITLE
Add pip and docker ecosystems to Dependabot config

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -12,3 +12,11 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This pull request updates the Dependabot configuration to enable automated dependency updates for Python and Docker in addition to the existing settings.

Dependabot configuration enhancements:

* Added support for the `pip` package ecosystem to automate Python dependency updates on a weekly schedule in the root directory.
* Added support for the `docker` package ecosystem to automate Docker dependency updates on a weekly schedule in the root directory.